### PR TITLE
fixed add-user and remove-user APIs

### DIFF
--- a/routes/groupRoute.js
+++ b/routes/groupRoute.js
@@ -6,8 +6,6 @@ const router = express.Router();
 const { createGroup, addUser, makeGroupPermanent, removeUser, nearestGroup, fetchLastMessages, fetchGroupDetails } = require("../controllers/groupController");
 
 
-const router = express.Router();
-
 router.route("/remove-user").delete(removeUser);
 router.route("/make-group-permanent").put(makeGroupPermanent);
 router.route("/add-user").post(addUser);

--- a/utils/jwtToken.js
+++ b/utils/jwtToken.js
@@ -6,14 +6,16 @@ const sendToken = (user, statusCode, res) => {
       Date.now() + process.env.COOKIE_EXPIRY * 24 * 60 * 60 * 1000
     ),
     httpOnly: true,
-   
   };
 
-  res.status(statusCode).cookie("token", token, options).json({
-    success: true,
-    token,
-    user
-  })
+  // res.status(statusCode).cookie("token", token, options).json({
+  //   success: true,
+  //   token,
+  //   user
+  // })
+  res.status(statusCode)
+  res.setHeader("Authorization", token);
+  res.send();
 };
 
 module.exports = sendToken;


### PR DESCRIPTION
Now, we can remove a user from a group and add a new one. Both the effects will be reflected in the Groups and Users Database collections.